### PR TITLE
Updated /config/create API to accept an user config property

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1254,8 +1254,10 @@ module.exports = function(router) {
         newConfig = { ...newConfig, ...shareablePart };
       }
 
-      const { sharedConfig, ...otherBodyParams } = req.body;
-      newConfig = { ...newConfig, ...otherBodyParams };
+      if (req.body.config) {
+        const userConfig = req.body.config;
+        newConfig = { ...newConfig, ...userConfig };
+      }
 
       const configHash = await compressConfig(newConfig);
       res.json({ success: true, configHash });


### PR DESCRIPTION
Changes needed for the Bootstrapper integration. The user config can be obtained through the /:hashConfig/config API, but there is no current API to hash the config back.