### PR TITLE
fix: remove date from version number

### DIFF
--- a/src/addon/addonBuilder.js
+++ b/src/addon/addonBuilder.js
@@ -279,7 +279,7 @@ async function createAddon(userConfig) {
   await initTraktApi(userConfig);
   const manifest = {
     id: 'org.stremio.aiolists',
-    version: `1.2.7-${Date.now()}`,
+    version: '1.2.7',
     name: 'AIOLists',
     description: 'Manage all your lists in one place.',
     resources: ['catalog', 'meta'],


### PR DESCRIPTION
Appending the current date results in the version number being different on every reload. This causes glitches in Stremio and other external services because Stremio addons are assumed to have immutable manifests per unique URL.

An example of an external service is  the communtiy addon list over at https://stremio-addons.net/. Your addon keeps appearing in the  'recently updated' catalog because the automated system compares the manifest version numbers. Because the version number is always different, the addon keeps showing up in there even though the addon wasn't really updated at all.