### PR TITLE
add brazilian portuguese to language options

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -122,6 +122,7 @@ const tmdbLanguages = [
   { iso_639_1: "pi", english_name: "Pali" },
   { iso_639_1: "pl", english_name: "Polish" },
   { iso_639_1: "pt", english_name: "Portuguese" },
+  { iso_639_1: "pt-BR", english_name: "Brazilian Portuguese" },
   { iso_639_1: "qu", english_name: "Quechua" },
   { iso_639_1: "rm", english_name: "Raeto-Romance" },
   { iso_639_1: "ro", english_name: "Romanian" },


### PR DESCRIPTION
It is stated in the [TMDB API documentation](https://developer.themoviedb.org/docs/languages) that ISO 3166-1 is also supported.  

> You'll usually find our language codes mated to a country code in the format of en-US. The country codes in use here are ISO 3166-1.  

This solves #64 and #79