### PR TITLE
fix (#60): resolve manifest failing to copy to clipboard

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2249,7 +2249,9 @@ function startNameEditing(listItemElement, list) {
     }
     
     try {
-      await navigator.clipboard.writeText(elements.updateStremioBtn.href);
+      setTimeout(() => {
+        navigator.clipboard.writeText(elements.updateStremioBtn.href.replace("stremio://", `${window.location.protocol}//`)).then(() => { console.log("Copied to clipboard!"); }).catch(err => { throw err; });
+      }, 10);
       const originalContent = elements.copyManifestBtn.innerHTML;
       elements.copyManifestBtn.innerHTML = '<span>Copied!</span>'; elements.copyManifestBtn.disabled = true;
       setTimeout(() => { elements.copyManifestBtn.innerHTML = originalContent; elements.copyManifestBtn.disabled = false; }, 2000);


### PR DESCRIPTION
Update clipboard copy functionality with a delay since certain browsers fail to copy due to [transient activation](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations) issues.
